### PR TITLE
Fix spelling of SDK repository URL

### DIFF
--- a/repository/21/addon.xml
+++ b/repository/21/addon.xml
@@ -24,7 +24,7 @@
         <sdk:vendor>Giesecke Devrient GmbH</sdk:vendor>
         <sdk:revision>01</sdk:revision>
         <sdk:description>SIMalliance Open Mobile API for Android</sdk:description>
-        <sdk:desc-url>seek-for-android.github.io/reposiroty/21/</sdk:desc-url>
+        <sdk:desc-url>seek-for-android.github.io/repository/21/</sdk:desc-url>
         <sdk:uses-license ref="android-sdk-license" />
         <sdk:archives>
             <sdk:archive os="any">


### PR DESCRIPTION
This PR fixes the spelling of the URL in the sdk:desc-url attribute of the repository add-on manifest ("reposiroty" vs. "repository").